### PR TITLE
Refactor: deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,18 @@ const obj = new ExampleClass(42, 2048, 131_072, BigInt(4_000_000_000));
 const serialized = obj.serialize();
 ```
 
-The deserialization currently works on a empty object of this class and fills its properties:
+The deserialization uses the helper method `deserialize` which takes the raw bytes and the target type:
 
 ```typescript
 const bytes = new Uint8Array([
   0x81, 0x88, 0x27, 0xb3, 0xa7, 0x2f, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 ]);
-const obj = new ExampleClass();
-obj.deserialize(bytes);
+
+const obj = deserialize(bytes, ExampleClass);
 ```
 
-**Note**: Especially the deserialization is subject to change. The method of using a already created object and filling it with data is probably not the greatest solution, but the best one I could find so far.
+**Note**: Deserialization currently works using a empty object and filling it with data.
+This is probably not the greatest solution, but the best one I could find so far.
 If you can think of any other way of dealing with this please let me know.
 
 Examples for more complex applications can also be found in the integration tests `/tests/integration/`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class ExampleClass implements Serializable {
   public serialize(): Uint8Array {
     throw new Error('Method not implemented.');
   }
-  public deserialize(bytes: AppendableByteStream): void {
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -70,10 +70,10 @@ const bytes = new Uint8Array([
   0x81, 0x88, 0x27, 0xb3, 0xa7, 0x2f, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 ]);
 const obj = new ExampleClass();
-obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+obj.deserialize(bytes);
 ```
 
-**Note**: Especially the deserialization is subject to change. The method of using a already created object and filling it with data is not the greatest solution.
-Also the parameters of deserialize-method will probably change.
+**Note**: Especially the deserialization is subject to change. The method of using a already created object and filling it with data is probably not the greatest solution, but the best one I could find so far.
+If you can think of any other way of dealing with this please let me know.
 
 Examples for more complex applications can also be found in the integration tests `/tests/integration/`

--- a/src/appendable-byte-stream.ts
+++ b/src/appendable-byte-stream.ts
@@ -1,0 +1,8 @@
+/**
+ * Represents a bytestream which allows appending more bytes using a DataView
+ */
+export class AppendableByteStream {
+  constructor(public view: DataView, public pos: number = 0, public littleEndian: boolean = true) {}
+
+  //TODO: add append functions
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,14 @@
+import { AppendableByteStream } from './appendable-byte-stream';
+import { Serializable } from './serializable';
+
 //TODO: restructure exports
 export { Serializable } from './serializable';
 export { AppendableByteStream } from './appendable-byte-stream';
 export * from './serializable-primitives/index';
 export * from './decorators/index';
+
+export const deserialize = <T extends Serializable>(bytes: Uint8Array, type: { new (...args: any[]): T }): T => {
+  const object = new type();
+  object.deserialize(bytes);
+  return object;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 //TODO: restructure exports
-export { Serializable, AppendableByteStream } from './serializable';
+export { Serializable } from './serializable';
+export { AppendableByteStream } from './appendable-byte-stream';
 export * from './serializable-primitives/index';
 export * from './decorators/index';

--- a/src/serializable-primitives/serializable-bigint.ts
+++ b/src/serializable-primitives/serializable-bigint.ts
@@ -1,5 +1,6 @@
 import { SerializablePrimitive } from './serializable-primitive';
-import { AppendableByteStream, isAppendableByteStream } from '../serializable';
+import { isAppendableByteStream } from '../serializable';
+import { AppendableByteStream } from '../appendable-byte-stream';
 
 /**
  * Build a new class for a serializable bigint
@@ -9,8 +10,8 @@ import { AppendableByteStream, isAppendableByteStream } from '../serializable';
  */
 const buildSerializableBigintPrimitive = (
   size: number,
-  getFun: (view: DataView, pos: number, littleEndian?: boolean) => bigint,
-  setFun: (view: DataView, pos: number, value: bigint, littleEndian?: boolean) => void
+  getFun: (bytestream: AppendableByteStream) => bigint,
+  setFun: (bytestream: AppendableByteStream, value: bigint) => void
 ): new (data?: bigint | AppendableByteStream) => SerializablePrimitive<bigint> => {
   return class SerializableBigIntPrimitive extends SerializablePrimitive<bigint> {
     public readonly size = size;
@@ -23,12 +24,12 @@ const buildSerializableBigintPrimitive = (
     }
 
     public append(bytestream: AppendableByteStream): void {
-      setFun(bytestream.view, bytestream.pos, this.value ?? 0, bytestream.littleEndian);
+      setFun(bytestream, this.value ?? 0);
       bytestream.pos += this.size;
     }
 
     protected readFromByteStream(bytestream: AppendableByteStream): bigint {
-      const value = getFun(bytestream.view, bytestream.pos, bytestream.littleEndian);
+      const value = getFun(bytestream);
       bytestream.pos += this.size;
       return value;
     }
@@ -37,12 +38,12 @@ const buildSerializableBigintPrimitive = (
 
 export const Uint64 = buildSerializableBigintPrimitive(
   8,
-  (view, pos) => view.getBigUint64(pos),
-  (view, pos, value) => view.setBigUint64(pos, value)
+  (bytestream) => bytestream.view.getBigUint64(bytestream.pos),
+  (bytestream, value) => bytestream.view.setBigUint64(bytestream.pos, value)
 );
 
 export const Int64 = buildSerializableBigintPrimitive(
   8,
-  (view, pos) => view.getBigInt64(pos),
-  (view, pos, value) => view.setBigInt64(pos, value)
+  (bytestream) => bytestream.view.getBigInt64(bytestream.pos),
+  (bytestream, value) => bytestream.view.setBigInt64(bytestream.pos, value)
 );

--- a/src/serializable-primitives/serializable-number.ts
+++ b/src/serializable-primitives/serializable-number.ts
@@ -1,4 +1,5 @@
-import { AppendableByteStream, isAppendableByteStream } from '../serializable';
+import { isAppendableByteStream } from '../serializable';
+import { AppendableByteStream } from '../appendable-byte-stream';
 import { SerializablePrimitive } from './serializable-primitive';
 
 /**
@@ -9,8 +10,8 @@ import { SerializablePrimitive } from './serializable-primitive';
  */
 const buildSerializableNumberPrimitive = (
   size: number,
-  getFun: (view: DataView, pos: number, littleEndian?: boolean) => number,
-  setFun: (view: DataView, pos: number, value: number, littleEndian?: boolean) => void
+  getFun: (bytestream: AppendableByteStream) => number,
+  setFun: (bytestream: AppendableByteStream, value: number) => void
 ): new (data?: number | AppendableByteStream) => SerializablePrimitive<number> => {
   return class SerializableNumberPrimitive extends SerializablePrimitive<number> {
     public readonly size = size;
@@ -23,12 +24,12 @@ const buildSerializableNumberPrimitive = (
     }
 
     public append(bytestream: AppendableByteStream): void {
-      setFun(bytestream.view, bytestream.pos, this.value ?? 0, bytestream.littleEndian);
+      setFun(bytestream, this.value ?? 0);
       bytestream.pos += this.size;
     }
 
     protected readFromByteStream(bytestream: AppendableByteStream): number {
-      const value = getFun(bytestream.view, bytestream.pos, bytestream.littleEndian);
+      const value = getFun(bytestream);
       bytestream.pos += this.size;
       return value;
     }
@@ -37,48 +38,48 @@ const buildSerializableNumberPrimitive = (
 
 export const Uint8 = buildSerializableNumberPrimitive(
   1,
-  (view, pos) => view.getUint8(pos),
-  (view, pos, value) => view.setUint8(pos, value)
+  (bytestream) => bytestream.view.getUint8(bytestream.pos),
+  (bytestream, value) => bytestream.view.setUint8(bytestream.pos, value)
 );
 
 export const Uint16 = buildSerializableNumberPrimitive(
   2,
-  (view, pos, littleEndian) => view.getUint16(pos, littleEndian),
-  (view, pos, value, littleEndian) => view.setUint16(pos, value, littleEndian)
+  (bytestream) => bytestream.view.getUint16(bytestream.pos, bytestream.littleEndian),
+  (bytestream, value) => bytestream.view.setUint16(bytestream.pos, value, bytestream.littleEndian)
 );
 
 export const Uint32 = buildSerializableNumberPrimitive(
   4,
-  (view, pos, littleEndian) => view.getUint32(pos, littleEndian),
-  (view, pos, value, littleEndian) => view.setUint32(pos, value, littleEndian)
+  (bytestream) => bytestream.view.getUint32(bytestream.pos, bytestream.littleEndian),
+  (bytestream, value) => bytestream.view.setUint32(bytestream.pos, value, bytestream.littleEndian)
 );
 
 export const Int8 = buildSerializableNumberPrimitive(
   1,
-  (view, pos) => view.getInt8(pos),
-  (view, pos, value) => view.setInt8(pos, value)
+  (bytestream) => bytestream.view.getInt8(bytestream.pos),
+  (bytestream, value) => bytestream.view.setInt8(bytestream.pos, value)
 );
 
 export const Int16 = buildSerializableNumberPrimitive(
   2,
-  (view, pos, littleEndian) => view.getInt16(pos, littleEndian),
-  (view, pos, value, littleEndian) => view.setInt16(pos, value, littleEndian)
+  (bytestream) => bytestream.view.getInt16(bytestream.pos, bytestream.littleEndian),
+  (bytestream, value) => bytestream.view.setInt16(bytestream.pos, value, bytestream.littleEndian)
 );
 
 export const Int32 = buildSerializableNumberPrimitive(
   4,
-  (view, pos, littleEndian) => view.getInt32(pos, littleEndian),
-  (view, pos, value, littleEndian) => view.setInt32(pos, value, littleEndian)
+  (bytestream) => bytestream.view.getInt32(bytestream.pos, bytestream.littleEndian),
+  (bytestream, value) => bytestream.view.setInt32(bytestream.pos, value, bytestream.littleEndian)
 );
 
 export const Float32 = buildSerializableNumberPrimitive(
   4,
-  (view, pos, littleEndian) => view.getFloat32(pos, littleEndian),
-  (view, pos, value, littleEndian) => view.setFloat32(pos, value, littleEndian)
+  (bytestream) => bytestream.view.getFloat32(bytestream.pos, bytestream.littleEndian),
+  (bytestream, value) => bytestream.view.setFloat32(bytestream.pos, value, bytestream.littleEndian)
 );
 
 export const Float64 = buildSerializableNumberPrimitive(
   8,
-  (view, pos, littleEndian) => view.getFloat64(pos, littleEndian),
-  (view, pos, value, littleEndian) => view.setFloat64(pos, value, littleEndian)
+  (bytestream) => bytestream.view.getFloat64(bytestream.pos, bytestream.littleEndian),
+  (bytestream, value) => bytestream.view.setFloat64(bytestream.pos, value, bytestream.littleEndian)
 );

--- a/src/serializable-primitives/serializable-primitive.ts
+++ b/src/serializable-primitives/serializable-primitive.ts
@@ -1,4 +1,5 @@
-import { AppendableByteStream, isAppendableByteStream, isSerializable, Serializable } from '../serializable';
+import { isAppendableByteStream, isSerializable, Serializable } from '../serializable';
+import { AppendableByteStream } from '../appendable-byte-stream';
 
 /**
  * Generic base class for serializable primitives to serve as building blocks for complex serializable types
@@ -34,7 +35,7 @@ export abstract class SerializablePrimitive<T> implements Serializable {
 
   public serialize(): Uint8Array {
     const array = new Uint8Array(this.size);
-    this.append({ view: new DataView(array.buffer), pos: 0 });
+    this.append(new AppendableByteStream(new DataView(array.buffer), 0));
     return array;
   }
 }

--- a/src/serializable-primitives/serializable-string.ts
+++ b/src/serializable-primitives/serializable-string.ts
@@ -1,5 +1,5 @@
 import { SerializablePrimitive } from './serializable-primitive';
-import { AppendableByteStream } from '../serializable';
+import { AppendableByteStream } from '../appendable-byte-stream';
 
 /**
  * serializable array of bytes (based upon Uint8array)

--- a/src/serializable-primitives/serializable-uint8-array.ts
+++ b/src/serializable-primitives/serializable-uint8-array.ts
@@ -1,5 +1,5 @@
 import { SerializablePrimitive } from './serializable-primitive';
-import { AppendableByteStream } from '../serializable';
+import { AppendableByteStream } from '../appendable-byte-stream';
 
 /**
  * serializable array of bytes (based upon Uint8array)

--- a/src/serializable.ts
+++ b/src/serializable.ts
@@ -1,21 +1,13 @@
+import { AppendableByteStream } from './appendable-byte-stream';
+
 /**
  * A type that can be serialized to and deserialized from a bytestream
  */
 export interface Serializable {
   serialize(): Uint8Array;
 
-  deserialize(bytes: AppendableByteStream): void;
+  deserialize(bytes: AppendableByteStream | Uint8Array): void;
 }
-
-/**
- * Represents a bytestream which allows appending more bytes
- */
-export type AppendableByteStream = {
-  //TODO: maybe move to class
-  view: DataView;
-  pos: number;
-  littleEndian?: boolean;
-};
 
 export const isSerializable = (checkObject: any): checkObject is Serializable =>
   typeof checkObject === 'object' && 'serialize' in checkObject;

--- a/tests/integration/bug-instances-share-data.spec.ts
+++ b/tests/integration/bug-instances-share-data.spec.ts
@@ -5,7 +5,7 @@ import {
   Serializable,
   SerializableClass,
   AppendableByteStream
-} from "../../src/index";
+} from '../../src/index';
 
 @SerializableClass({ littleEndian: true })
 class ExampleClass implements Serializable {
@@ -18,8 +18,7 @@ class ExampleClass implements Serializable {
   @SerializableNumber(Uint8)
   public secondTestByte: number = 0;
 
-  constructor(byte: number = 0, ushort: number = 0, secondByte: number = 0) {
-  }
+  constructor(byte: number = 0, ushort: number = 0, secondByte: number = 0) {}
 
   public init(byte: number = 0, ushort: number = 0, secondByte: number = 0) {
     this.testByte = byte;
@@ -28,16 +27,16 @@ class ExampleClass implements Serializable {
   }
 
   public serialize(): Uint8Array {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
 
-  public deserialize(bytes: AppendableByteStream): void {
-    throw new Error("Method not implemented.");
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
+    throw new Error('Method not implemented.');
   }
 }
 
-describe("Bug: Multiple instances should not share underlying data", () => {
-  it("instances created with different values should not be equal", () => {
+describe('Bug: Multiple instances should not share underlying data', () => {
+  it('instances created with different values should not be equal', () => {
     const obj1 = new ExampleClass(42, 2048, 5);
     const obj2 = new ExampleClass(5, 1, 10);
     expect(obj1).not.toEqual(obj2);

--- a/tests/integration/complex-serializable-class.spec.ts
+++ b/tests/integration/complex-serializable-class.spec.ts
@@ -7,7 +7,8 @@ import {
   SerializableByteArray,
   SerializableClass,
   Serializable,
-  AppendableByteStream
+  AppendableByteStream,
+  deserialize
 } from '../../src/index';
 
 @SerializableClass({ littleEndian: true })
@@ -86,8 +87,7 @@ describe('Complex serializable class with serializable object property', () => {
     const bytes = new Uint8Array([0x8a, 0x2c, 0x00, 0x03, 0x00, 0x00, 0x00, 0x03, 0x02, 0x01]);
     const expectedObj = new ExampleFrame(new ExampleHeader(138, 44), 3, new Uint8Array([0x03, 0x02, 0x01]));
 
-    const obj = new ExampleFrame();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleFrame);
     expect(obj).toEqual(expectedObj);
   });
 

--- a/tests/integration/complex-serializable-class.spec.ts
+++ b/tests/integration/complex-serializable-class.spec.ts
@@ -29,7 +29,7 @@ class ExampleHeader implements Serializable {
     throw new Error('Method not implemented.');
   }
 
-  deserialize(bytes: AppendableByteStream): void {
+  deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -65,7 +65,7 @@ class ExampleFrame implements Serializable {
     throw new Error('Method not implemented.');
   }
 
-  deserialize(bytes: AppendableByteStream): void {
+  deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -87,7 +87,7 @@ describe('Complex serializable class with serializable object property', () => {
     const expectedObj = new ExampleFrame(new ExampleHeader(138, 44), 3, new Uint8Array([0x03, 0x02, 0x01]));
 
     const obj = new ExampleFrame();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
   });
 

--- a/tests/integration/serializable-class-with-custom-length-byte-array.spec.ts
+++ b/tests/integration/serializable-class-with-custom-length-byte-array.spec.ts
@@ -22,7 +22,7 @@ class ExampleClass implements Serializable {
     throw new Error('Method not implemented.');
   }
 
-  public deserialize(bytes: AppendableByteStream): void {
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -46,7 +46,7 @@ class ExampleClass1 implements Serializable {
     throw new Error('Method not implemented.');
   }
 
-  public deserialize(bytes: AppendableByteStream): void {
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -65,7 +65,7 @@ describe('Serializable class with fixed-length byteArray ', () => {
     const expectedObj = new ExampleClass(new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]));
 
     const obj = new ExampleClass();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
     expect(obj.testArray.length).toBe(5);
   });
@@ -75,7 +75,7 @@ describe('Serializable class with fixed-length byteArray ', () => {
     const expectedObj = new ExampleClass(new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]));
 
     const obj = new ExampleClass();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
     expect(obj.testArray.length).toBe(5);
   });
@@ -101,7 +101,7 @@ describe('Serializable class with dynamic-length byteArray ', () => {
     const expectedObj = new ExampleClass1(3, new Uint8Array([0x00, 0x01, 0x02]));
 
     const obj = new ExampleClass1();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
   });
 
@@ -110,7 +110,7 @@ describe('Serializable class with dynamic-length byteArray ', () => {
     const expectedObj = new ExampleClass1(5, new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]));
 
     const obj = new ExampleClass1();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
   });
 

--- a/tests/integration/serializable-class-with-custom-length-byte-array.spec.ts
+++ b/tests/integration/serializable-class-with-custom-length-byte-array.spec.ts
@@ -1,5 +1,6 @@
 import {
   AppendableByteStream,
+  deserialize,
   Serializable,
   SerializableByteArray,
   SerializableClass,
@@ -64,8 +65,7 @@ describe('Serializable class with fixed-length byteArray ', () => {
     const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]);
     const expectedObj = new ExampleClass(new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]));
 
-    const obj = new ExampleClass();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass);
     expect(obj).toEqual(expectedObj);
     expect(obj.testArray.length).toBe(5);
   });
@@ -74,8 +74,7 @@ describe('Serializable class with fixed-length byteArray ', () => {
     const bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0a]);
     const expectedObj = new ExampleClass(new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]));
 
-    const obj = new ExampleClass();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass);
     expect(obj).toEqual(expectedObj);
     expect(obj.testArray.length).toBe(5);
   });
@@ -100,8 +99,7 @@ describe('Serializable class with dynamic-length byteArray ', () => {
     const bytes = new Uint8Array([0x03, 0x00, 0x01, 0x02]);
     const expectedObj = new ExampleClass1(3, new Uint8Array([0x00, 0x01, 0x02]));
 
-    const obj = new ExampleClass1();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass1);
     expect(obj).toEqual(expectedObj);
   });
 
@@ -109,8 +107,7 @@ describe('Serializable class with dynamic-length byteArray ', () => {
     const bytes = new Uint8Array([0x05, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x0a]);
     const expectedObj = new ExampleClass1(5, new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]));
 
-    const obj = new ExampleClass1();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass1);
     expect(obj).toEqual(expectedObj);
   });
 

--- a/tests/integration/serializable-class-with-simple-byte-array.spec.ts
+++ b/tests/integration/serializable-class-with-simple-byte-array.spec.ts
@@ -24,7 +24,7 @@ class ExampleClass implements Serializable {
     throw new Error('Method not implemented.');
   }
 
-  public deserialize(bytes: AppendableByteStream): void {
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -48,7 +48,7 @@ class ExampleClass1 implements Serializable {
     throw new Error('Method not implemented.');
   }
 
-  public deserialize(bytes: AppendableByteStream): void {
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -67,7 +67,7 @@ describe('Serializable class with byteArray only', () => {
     const expectedObj = new ExampleClass(new Uint8Array([0x00, 0x01, 0x02]));
 
     const obj = new ExampleClass();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
   });
 
@@ -92,7 +92,7 @@ describe('Serializable class with primitive and byteArray', () => {
     const expectedObj = new ExampleClass1(42, new Uint8Array([0x00, 0x01, 0x02]));
 
     const obj = new ExampleClass1();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
   });
 

--- a/tests/integration/serializable-class-with-simple-byte-array.spec.ts
+++ b/tests/integration/serializable-class-with-simple-byte-array.spec.ts
@@ -1,6 +1,7 @@
 import {
   AppendableByteStream,
   ByteArray,
+  deserialize,
   Serializable,
   SerializableByteArray,
   SerializableClass,
@@ -66,8 +67,7 @@ describe('Serializable class with byteArray only', () => {
     const bytes = new Uint8Array([0x00, 0x01, 0x02]);
     const expectedObj = new ExampleClass(new Uint8Array([0x00, 0x01, 0x02]));
 
-    const obj = new ExampleClass();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass);
     expect(obj).toEqual(expectedObj);
   });
 
@@ -91,8 +91,7 @@ describe('Serializable class with primitive and byteArray', () => {
     const bytes = new Uint8Array([0x2a, 0x00, 0x00, 0x01, 0x02]);
     const expectedObj = new ExampleClass1(42, new Uint8Array([0x00, 0x01, 0x02]));
 
-    const obj = new ExampleClass1();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass1);
     expect(obj).toEqual(expectedObj);
   });
 

--- a/tests/integration/serializable-class-with-string-field.spec.ts
+++ b/tests/integration/serializable-class-with-string-field.spec.ts
@@ -1,6 +1,7 @@
 import {
   AppendableByteStream,
   ByteArray,
+  deserialize,
   Serializable,
   SerializableByteArray,
   SerializableClass,
@@ -43,8 +44,8 @@ describe('Serializable class with string-field', () => {
     const bytes = new Uint8Array([0x54, 0x45, 0x53, 0x54]);
     const expectedObj = new ExampleClass('TEST');
 
-    const obj = new ExampleClass();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass);
+
     expect(obj).toEqual(expectedObj);
   });
 
@@ -52,8 +53,7 @@ describe('Serializable class with string-field', () => {
     const bytes = new Uint8Array([0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]);
     const expectedObj = new ExampleClass('ABCD');
 
-    const obj = new ExampleClass();
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass);
     expect(obj).toEqual(expectedObj);
   });
 });

--- a/tests/integration/serializable-class-with-string-field.spec.ts
+++ b/tests/integration/serializable-class-with-string-field.spec.ts
@@ -25,7 +25,7 @@ class ExampleClass implements Serializable {
     throw new Error('Method not implemented.');
   }
 
-  public deserialize(bytes: AppendableByteStream): void {
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -44,7 +44,7 @@ describe('Serializable class with string-field', () => {
     const expectedObj = new ExampleClass('TEST');
 
     const obj = new ExampleClass();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
   });
 
@@ -53,7 +53,7 @@ describe('Serializable class with string-field', () => {
     const expectedObj = new ExampleClass('ABCD');
 
     const obj = new ExampleClass();
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     expect(obj).toEqual(expectedObj);
   });
 });

--- a/tests/integration/simple-serializable-class.spec.ts
+++ b/tests/integration/simple-serializable-class.spec.ts
@@ -7,8 +7,8 @@ import {
   Serializable,
   SerializableClass,
   AppendableByteStream
-} from "../../src/index";
-import { Float32, Float64 } from "../../src/serializable-primitives/serializable-number";
+} from '../../src/index';
+import { Float32, Float64 } from '../../src/serializable-primitives/serializable-number';
 
 @SerializableClass({ littleEndian: true })
 class ExampleClass implements Serializable {
@@ -37,9 +37,7 @@ class ExampleClass implements Serializable {
     ulong: bigint = BigInt(0),
     float: number = 0.0,
     double: number = 0.0
-  ) {
-
-  }
+  ) {}
 
   public init(
     byte: number = 0,
@@ -58,16 +56,16 @@ class ExampleClass implements Serializable {
   }
 
   public serialize(): Uint8Array {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
 
-  public deserialize(bytes: AppendableByteStream): void {
-    throw new Error("Method not implemented.");
+  public deserialize(bytes: AppendableByteStream | Uint8Array): void {
+    throw new Error('Method not implemented.');
   }
 }
 
-describe("Serializable class with primitives only", () => {
-  it("object should serialize into Uint8Array", () => {
+describe('Serializable class with primitives only', () => {
+  it('object should serialize into Uint8Array', () => {
     const obj = new ExampleClass(42, 2048, 131_072, BigInt(4_000_000_000), 13.42, 15.123);
     const expectedBytes = new Uint8Array([
       0x2a, 0x00, 0x08, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xee, 0x6b, 0x28, 0x00, 0x52, 0xb8, 0x56, 0x41,
@@ -78,17 +76,16 @@ describe("Serializable class with primitives only", () => {
     expect(serialized).toEqual(expectedBytes);
   });
 
-  it("deserialize should return object", () => {
+  it('deserialize should return object', () => {
     const bytes = new Uint8Array([
       0x2a, 0x00, 0x08, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0xee, 0x6b, 0x28, 0x00, 0x52, 0xb8, 0x56, 0x41,
       0xe5, 0xd0, 0x22, 0xdb, 0xf9, 0x3e, 0x2e, 0x40
     ]);
     const expectedObj = new ExampleClass(42, 2048, 131_072, BigInt(4_000_000_000), 13.42, 15.123);
 
-    //TODO: allow deserialize with Uint8Array directly
     const obj = new ExampleClass();
     //TODO: add deserialize function that returns an object
-    obj.deserialize({ view: new DataView(bytes.buffer), pos: 0, littleEndian: true });
+    obj.deserialize(bytes);
     //manual check because of floating point rounding issues
     expect(obj.testByte).toEqual(expectedObj.testByte);
     expect(obj.testUShort).toEqual(expectedObj.testUShort);
@@ -98,12 +95,9 @@ describe("Serializable class with primitives only", () => {
     expect(obj.testDouble).toBeCloseTo(expectedObj.testDouble);
   });
 
-  it("instances created with different values should not be equal", () => {
-
+  it('instances created with different values should not be equal', () => {
     const obj1 = new ExampleClass(129, 10_120, 3_123_123, BigInt(42), 13.42, 15.123);
     const obj2 = new ExampleClass(12, 150, 3000, BigInt(12345), 0.42, 0.321);
     expect(obj1).not.toEqual(obj2);
   });
 });
-
-

--- a/tests/integration/simple-serializable-class.spec.ts
+++ b/tests/integration/simple-serializable-class.spec.ts
@@ -6,7 +6,8 @@ import {
   Uint64,
   Serializable,
   SerializableClass,
-  AppendableByteStream
+  AppendableByteStream,
+  deserialize
 } from '../../src/index';
 import { Float32, Float64 } from '../../src/serializable-primitives/serializable-number';
 
@@ -83,9 +84,8 @@ describe('Serializable class with primitives only', () => {
     ]);
     const expectedObj = new ExampleClass(42, 2048, 131_072, BigInt(4_000_000_000), 13.42, 15.123);
 
-    const obj = new ExampleClass();
-    //TODO: add deserialize function that returns an object
-    obj.deserialize(bytes);
+    const obj = deserialize(bytes, ExampleClass);
+
     //manual check because of floating point rounding issues
     expect(obj.testByte).toEqual(expectedObj.testByte);
     expect(obj.testUShort).toEqual(expectedObj.testUShort);


### PR DESCRIPTION
Fixes multiple issues with deserialization:

- Change parameter-type for easier use of serializable.deserialize fixes #14 
- Add helper method `deserialize` for simpler deserialization overall